### PR TITLE
Reconcile kubernetes-current from the running kubelet versions

### DIFF
--- a/internal/kubernetescluster/talos/highest_kubelet_version_test.go
+++ b/internal/kubernetescluster/talos/highest_kubelet_version_test.go
@@ -1,0 +1,71 @@
+package talos
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func nodesRunning(versions ...string) []corev1.Node {
+	nodes := make([]corev1.Node, 0, len(versions))
+	for _, v := range versions {
+		var n corev1.Node
+		n.Status.NodeInfo.KubeletVersion = v
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+func TestHighestKubeletVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		nodes []corev1.Node
+		want  string
+	}{
+		{
+			// A settled cluster after an upgrade: every node agrees.
+			name:  "all nodes on the same version",
+			nodes: nodesRunning("v1.36.2", "v1.36.2", "v1.36.2", "v1.36.2"),
+			want:  "1.36.2",
+		},
+		{
+			// The straggler case reconcileNodeVersions exists for. Taking the
+			// lowest would make the straggler the target and strand it there.
+			name:  "one node lagging behind the rest",
+			nodes: nodesRunning("v1.36.2", "v1.36.2", "v1.35.3"),
+			want:  "1.36.2",
+		},
+		{
+			name:  "mid-upgrade, most nodes not yet moved",
+			nodes: nodesRunning("v1.35.3", "v1.35.3", "v1.36.2"),
+			want:  "1.36.2",
+		},
+		{
+			// An unreadable version must not sink the answer for the rest.
+			name:  "one node reports something unparseable",
+			nodes: nodesRunning("v1.36.2", "not-a-version"),
+			want:  "1.36.2",
+		},
+		{
+			name:  "nothing parses",
+			nodes: nodesRunning("not-a-version"),
+			want:  "",
+		},
+		{
+			name:  "no nodes",
+			nodes: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := highestKubeletVersion(tt.nodes); got != tt.want {
+				t.Errorf("highestKubeletVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/kubernetescluster/talos/reconcile_nodes.go
+++ b/internal/kubernetescluster/talos/reconcile_nodes.go
@@ -367,6 +367,13 @@ func (t *TalosManager) reconcileNodeVersions(ctx context.Context, cluster *vitis
 		return fmt.Errorf("failed to list workload cluster nodes: %w", err)
 	}
 
+	// Re-resolve after the refresh so this pass acts on the corrected version
+	// rather than warning once more and fixing it next time round.
+	t.refreshKubernetesCurrentVersion(ctx, cluster, nodeList.Items)
+	if refreshed := t.desiredKubernetesVersion(ctx, cluster); refreshed != "" {
+		desiredVersion = consts.EnsureVersionPrefix(refreshed)
+	}
+
 	machines, err := t.machineService.GetClusterMachines(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster machines: %w", err)
@@ -474,6 +481,53 @@ func collectNodeUpgradeCandidates(
 
 // filterNodesNeedingUpgrade drops candidates whose Talos machine config already
 // carries the desired kubelet image — those just need the kubelet to restart.
+// refreshKubernetesCurrentVersion keeps the recorded Kubernetes version aligned
+// with what the cluster's nodes actually run.
+//
+// The orchestrated upgrade flow maintains this for user-driven upgrades, but an
+// upgrade performed outside it — by the version enforcer, by viti talos, by
+// hand — changes the running version without going through it. Left
+// unreconciled, every node then reads as "newer than desired" and
+// reconcileNodeVersions warns about all of them on every pass, forever.
+//
+// Best-effort: the nodes are already in hand here, so it costs no API call, and
+// a failure to record must not stop the enforcement it precedes.
+func (t *TalosManager) refreshKubernetesCurrentVersion(ctx context.Context, cluster *vitistackv1alpha1.KubernetesCluster, nodes []corev1.Node) {
+	if t.upgradeService == nil {
+		return
+	}
+	running := highestKubeletVersion(nodes)
+	if running == "" {
+		return
+	}
+	if err := t.upgradeService.ReconcileKubernetesCurrentVersion(ctx, cluster, running); err != nil {
+		vlog.Warn(fmt.Sprintf("Failed to refresh kubernetes-current for %s: %v", clusterLogTag(cluster), err))
+	}
+}
+
+// highestKubeletVersion returns the newest kubelet version across the cluster's
+// nodes, or "" when none parses.
+//
+// The highest rather than the lowest: a node lagging behind the rest is the
+// case reconcileNodeVersions exists to fix, so letting it define the cluster's
+// recorded version would make the straggler the target and strand it there.
+func highestKubeletVersion(nodes []corev1.Node) string {
+	var best *semver.Version
+	for i := range nodes {
+		v, err := semver.NewVersion(nodes[i].Status.NodeInfo.KubeletVersion)
+		if err != nil {
+			continue
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+		}
+	}
+	if best == nil {
+		return ""
+	}
+	return best.String()
+}
+
 func (t *TalosManager) filterNodesNeedingUpgrade(
 	ctx context.Context,
 	tClient *talosclient.Client,

--- a/internal/services/upgradeservice/reconcile_kubernetes_current_test.go
+++ b/internal/services/upgradeservice/reconcile_kubernetes_current_test.go
@@ -1,0 +1,64 @@
+package upgradeservice
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestRecordIsBehind(t *testing.T) {
+	t.Parallel()
+
+	running := semver.MustParse("1.36.2")
+
+	tests := []struct {
+		name     string
+		recorded string
+		want     bool
+	}{
+		{
+			// The observed failure: the recorded version sat a minor behind
+			// what every node was running.
+			name:     "recorded version is older",
+			recorded: "1.35.3",
+			want:     true,
+		},
+		{
+			name:     "recorded version matches",
+			recorded: "1.36.2",
+			want:     false,
+		},
+		{
+			// An orchestrated upgrade may record its target before the nodes
+			// get there. Dragging it back would undo the upgrade's own record.
+			name:     "recorded version is newer",
+			recorded: "1.37.0",
+			want:     false,
+		},
+		{
+			name:     "nothing recorded yet",
+			recorded: "",
+			want:     true,
+		},
+		{
+			// A value no reader can parse is not a reason to keep reporting it.
+			name:     "recorded version is unparseable",
+			recorded: "latest",
+			want:     true,
+		},
+		{
+			name:     "prefixed record still compares",
+			recorded: "v1.35.3",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := recordIsBehind(tt.recorded, running); got != tt.want {
+				t.Errorf("recordIsBehind(%q, %s) = %v, want %v", tt.recorded, running, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/upgradeservice/upgrade_service.go
+++ b/internal/services/upgradeservice/upgrade_service.go
@@ -325,6 +325,89 @@ func (s *UpgradeService) ReconcileTalosCurrentVersion(ctx context.Context, clust
 	return nil
 }
 
+// ReconcileKubernetesCurrentVersion brings the recorded Kubernetes version in
+// line with what the cluster's nodes actually run. It is the Kubernetes twin of
+// ReconcileTalosCurrentVersion, with two deliberate differences.
+//
+// It tracks the HIGHEST version observed, not the lowest. The Talos reconcile
+// uses the minimum because talos-current only feeds availability reporting;
+// kubernetes-current is additionally the desired version reconcileNodeVersions
+// pulls stragglers up to, so tracking the minimum would make desired equal the
+// least-upgraded node and nothing would ever be upgraded again. The maximum is
+// also what every consumer means by it: the version this cluster has been moved
+// to.
+//
+// And it writes the secret as well as the annotation. The secret outranks the
+// annotation for every reader, and nothing but InitializeCurrentVersions has
+// ever written it — not even CompleteKubernetesUpgrade, which
+// resolveCurrentKubernetesVersion documents as writing it. So a cluster
+// upgraded by any means kept reporting the version it was first seen at, and
+// reconcileNodeVersions warned about every node on every pass, forever.
+func (s *UpgradeService) ReconcileKubernetesCurrentVersion(ctx context.Context, cluster *vitistackv1alpha1.KubernetesCluster, running string) error {
+	if running == "" {
+		return nil
+	}
+	running = consts.NormalizeKubernetesVersion(running)
+	runningVer, err := semver.NewVersion(running)
+	if err != nil {
+		return nil
+	}
+
+	state := s.GetUpgradeState(cluster)
+	// An orchestrated upgrade owns these annotations while it is running.
+	if state.KubernetesStatus == consts.UpgradeStatusInProgress {
+		return nil
+	}
+
+	// The two records are checked independently rather than through the reader's
+	// precedence: an upgrade that updated the annotation and not the secret
+	// leaves them disagreeing, and comparing only the annotation would then see
+	// nothing to do while the secret — the one that is actually read — stays
+	// stale.
+	persisted := ""
+	if s.stateService != nil {
+		if v, verr := s.stateService.GetClusterVersions(ctx, cluster); verr == nil && v != nil {
+			persisted = consts.NormalizeKubernetesVersion(v.KubernetesVersion)
+		}
+	}
+	updateAnnotation := recordIsBehind(consts.NormalizeKubernetesVersion(state.KubernetesCurrent), runningVer)
+	updateSecret := s.stateService != nil && recordIsBehind(persisted, runningVer)
+	if !updateAnnotation && !updateSecret {
+		return nil
+	}
+
+	if updateAnnotation {
+		if err := s.SetUpgradeAnnotations(ctx, cluster, map[string]string{
+			consts.KubernetesCurrentAnnotation: running,
+		}); err != nil {
+			return err
+		}
+	}
+	if updateSecret {
+		if err := s.stateService.SetClusterVersions(ctx, cluster, "", running); err != nil {
+			return err
+		}
+	}
+
+	vlog.Info(fmt.Sprintf("Refreshed Kubernetes current version: %s current=%s annotation=%t secret=%t",
+		clusterlog.Tag(cluster), running, updateAnnotation, updateSecret))
+	return nil
+}
+
+// recordIsBehind reports whether a recorded version names something older than
+// running. An empty or unparseable record counts as behind: a value no reader
+// can use is not a reason to keep reporting a stale one.
+func recordIsBehind(recorded string, running *semver.Version) bool {
+	if recorded == "" {
+		return true
+	}
+	v, err := semver.NewVersion(recorded)
+	if err != nil {
+		return true
+	}
+	return running.GreaterThan(v)
+}
+
 // GetPersistedUpgradeState retrieves the upgrade state from the secret for recovery purposes.
 // This can be used to resume an interrupted upgrade.
 func (s *UpgradeService) GetPersistedUpgradeState(ctx context.Context, cluster *vitistackv1alpha1.KubernetesCluster) (*talosstateservice.UpgradeStateInfo, error) {


### PR DESCRIPTION
## The bug

The recorded Kubernetes version is written **once** — by `InitializeCurrentVersions`, when a cluster first becomes ready — and never again. `SetClusterVersions` has exactly one caller in the repo.

So any upgrade after that leaves it frozen: by the version enforcer, by a CLI, by hand, or by the operator's own `CompleteKubernetesUpgrade`. `desiredKubernetesVersion` then resolves to that stale value forever and `reconcileNodeVersions` logs, for every node on every pass:

```
Node <name> is running Kubernetes v1.36.2 which is newer than desired v1.35.3 — downgrade is not supported, skipping
```

Seen on two clusters. On one it produced 155 warnings in 15 minutes and stopped only when the secret was patched by hand.

## Reproduction

On a healthy cluster, set the secret's `kubernetes_version` one minor behind what the nodes run:

```sh
kubectl -n <ns> patch secret <cluster-id> --type merge \
  -p "{\"data\":{\"kubernetes_version\":\"$(printf 1.35.3 | base64)\"}}"
```

Warnings begin within one reconcile (~36s observed) and stop when it is set back. No node is touched — `reconcileNodeVersions` only upgrades nodes *below* desired, so all of them hit the `GreaterThan` branch and `continue`.

## The fix

Refresh it from the nodes `reconcileNodeVersions` has already listed, where the true kubelet versions are in hand — no extra API call. Two deliberate differences from `ReconcileTalosCurrentVersion`, both load-bearing:

**Highest version, not lowest.** `talos-current` only feeds availability reporting, so the minimum is safe there. `kubernetes-current` is *additionally* the desired version `reconcileNodeVersions` pulls stragglers up to — track the minimum and desired becomes the least-upgraded node, so the straggler defines the target and nothing is ever upgraded again.

**Writes the secret as well as the annotation**, checking each independently. The secret outranks the annotation for every reader, so an annotation-only refresh leaves the stale secret still answering. Confirmed live during the reproduction above:

```
annotation kubernetes-current = 1.36.2   ← correct
secret kubernetes_version     = 1.35.3   ← planted
operator says: desired v1.35.3           ← secret wins
```

Worth noting `resolveCurrentKubernetesVersion` documents `CompleteKubernetesUpgrade` as writing the secret — it does not.

## Behaviour

- A version that cannot be parsed counts as behind: a value no reader can use is not a reason to keep reporting a stale one.
- An orchestrated upgrade in progress is left alone; that flow owns the annotations.
- Best-effort — a failure to record must not stop the enforcement it precedes.

## Testing

`go build`, `go vet`, `make lint` (0 issues), `go test ./internal/...` all pass. Both new functions are pure and table-tested in the existing style, covering the straggler case, an in-flight upgrade recording ahead of its nodes, and unparseable values.

**Not covered:** no integration test — the repo has no envtest or fake-client harness for these packages, and the diagnosis was verified against live clusters rather than in CI. The fix itself has not been observed running; validating it needs a build deployed somewhere the operator can be scoped, which the shared management cluster does not allow.

The stale `talos_version` in the same secret has the same root cause and is left for a follow-up — it feeds the Talos enforcement path, where a mistake costs reboots rather than log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
